### PR TITLE
Implement execute() function

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -28,6 +28,9 @@ WriteMakefile(
       repository => 'https://github.com/iph0/Redis-ClusterRider',
       license    => 'http://dev.perl.org/licenses/',
     },
+    x_contributors => [
+      q{Sergei Zhmylev <zhmylove@cpan.org>},
+    ],
   },
   ABSTRACT_FROM => 'lib/Redis/ClusterRider.pm',
   AUTHOR        => 'Eugene Ponizovsky <ponizovsky@gmail.com>',

--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ The full list of the Redis commands can be found here: [http://redis.io/commands
     my $list    = $cluster->lrange( 'list', 0, -1 );
     my $counter = $cluster->incr('counter');
 
+## execute( $command [, @args ] )
+
+The alternative way of command execution is explicit "execute()" call.
+This approach is the only way if Redis commands contain punctuation,
+such as "GRAPH.QUERY" command of RedisGraph module.
+
+    my $list    = $cluster->execute('GRAPH.QUERY', $graph, $cypher_query);
+
+
 # TRANSACTIONS
 
 To perform the transaction you must get the master node by the key using

--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -417,6 +417,12 @@ sub _route {
   return $self->_execute( $cmd_name, $args, $nodes );
 }
 
+sub execute {
+  my $self     = shift;
+  my $cmd_name = shift;
+  return $self->_route( $cmd_name, [ @_ ] );
+}
+
 sub _execute {
   my $self     = shift;
   my $cmd_name = shift;
@@ -729,6 +735,14 @@ The full list of the Redis commands can be found here: L<http://redis.io/command
   my $value   = $cluster->get('foo');
   my $list    = $cluster->lrange( 'list', 0, -1 );
   my $counter = $cluster->incr('counter');
+
+=head2 execute( $command [, @args ] )
+
+The alternative way of command execution is explicit C<execute()> call.
+This approach is the only way if Redis commands contain punctuation, such as
+C<GRAPH.QUERY> command of RedisGraph module.
+
+  my $list    = $cluster->execute('GRAPH.QUERY', $graph, $cypher_query);
 
 =head1 TRANSACTIONS
 

--- a/t/03-commands.t
+++ b/t/03-commands.t
@@ -2,12 +2,13 @@ use 5.008000;
 use strict;
 use warnings;
 
-use Test::More tests => 8;
+use Test::More tests => 10;
 use Test::Fatal;
 BEGIN {
   require 't/test_helper.pl';
 }
 
+our @mock_keys;
 my $cluster = new_cluster(
   allow_slaves     => 1,
   refresh_interval => 5,
@@ -20,6 +21,7 @@ t_set($cluster);
 t_get($cluster);
 t_error_reply($cluster);
 t_multiword_command($cluster);
+t_keys($cluster);
 
 
 sub t_nodes {
@@ -108,6 +110,20 @@ sub t_multiword_command {
   my $t_reply = $cluster->client_getname;
 
   is( $t_reply, 'test', 'multiword command; CLIENT GETNAME' );
+
+  return;
+}
+
+sub t_keys {
+  my $cluster = shift;
+
+  my $t_reply = $cluster->keys( '*' );
+
+  is( $t_reply, 5, 'scalar; KEYS' );
+
+  my @t_reply = $cluster->keys( '*' );
+
+  is_deeply( \@t_reply, \@mock_keys, 'list; KEYS' );
 
   return;
 }

--- a/t/test_helper.pl
+++ b/t/test_helper.pl
@@ -48,6 +48,8 @@ BEGIN {
     client_getname  => 'test',
   );
 
+  our @mock_keys = qw( key1 key2 key3 key4 key5 );
+
   Test::MockObject->fake_module( 'Redis',
     new => sub {
       my $class  = shift;
@@ -68,6 +70,12 @@ BEGIN {
       $mock->mock( 'hget',
         sub {
           die '[hget] LOADING Redis is loading the dataset in memory';
+        }
+      );
+
+      $mock->mock( 'keys',
+        sub {
+          return wantarray ? @mock_keys : 0+@mock_keys;
         }
       );
 


### PR DESCRIPTION
Extends AUTOLOAD approach with explicit way of sending Redis commands. This approach covers Redis commands that can't be maped to Perl subroutines due to naming convention, such as "GRAPH.QUERY" from RedisGraph Module.