### PR TITLE
Implement execute() function

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,15 @@ The full list of the Redis commands can be found here: [http://redis.io/commands
     my $list    = $cluster->lrange( 'list', 0, -1 );
     my $counter = $cluster->incr('counter');
 
+## execute( $command [, @args ] )
+
+The alternative way of command execution is explicit "execute()" call.
+This approach is the only way if Redis commands contain punctuation,
+such as "GRAPH.QUERY" command of RedisGraph module.
+
+    my $list    = $cluster->execute('GRAPH.QUERY', $graph, $cypher_query);
+
+
 # TRANSACTIONS
 
 To perform the transaction you must get the master node by the key using

--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -417,6 +417,12 @@ sub _route {
   return $self->_execute( $cmd_name, $args, $nodes );
 }
 
+sub execute {
+  my $self     = shift;
+  my $cmd_name = shift;
+  return $self->_route( $cmd_name, [ @_ ] );
+}
+
 sub _execute {
   my $self     = shift;
   my $cmd_name = shift;
@@ -729,6 +735,14 @@ The full list of the Redis commands can be found here: L<http://redis.io/command
   my $value   = $cluster->get('foo');
   my $list    = $cluster->lrange( 'list', 0, -1 );
   my $counter = $cluster->incr('counter');
+
+=head2 execute( $command [, @args ] )
+
+The alternative way of command execution is explicit C<execute()> call.
+This approach is the only way if Redis commands contain punctuation, such as
+C<GRAPH.QUERY> command of RedisGraph module.
+
+  my $list    = $cluster->execute('GRAPH.QUERY', $graph, $cypher_query);
 
 =head1 TRANSACTIONS
 


### PR DESCRIPTION
Extends AUTOLOAD approach with explicit way of sending Redis commands. 
This approach covers Redis commands that can't be maped to Perl subroutines due to naming convention, such as "GRAPH.QUERY" from RedisGraph Module.