### PR TITLE
make sure to call _init

### DIFF
--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -384,9 +384,10 @@ sub _route {
   my $cmd_name = shift;
   my $args     = shift;
 
-  if ( $self->{refresh_interval} > 0
+  if ( ! defined $self->{_slots} || (
+    $self->{refresh_interval} > 0
     && Time::HiRes::tv_interval( $self->{_refresh_timestamp} )
-        > $self->{refresh_interval} )
+        > $self->{refresh_interval} ) )
   {
     $self->_init;
   }

--- a/t/03-commands.t
+++ b/t/03-commands.t
@@ -2,7 +2,7 @@ use 5.008000;
 use strict;
 use warnings;
 
-use Test::More tests => 11;
+use Test::More tests => 12;
 use Test::Fatal;
 BEGIN {
   require 't/test_helper.pl';
@@ -24,6 +24,12 @@ t_error_reply($cluster);
 t_multiword_command($cluster);
 t_keys($cluster);
 
+# try different combinations of options
+my $other_cluster = new_cluster(
+  refresh_interval => 0,
+  lazy => 1,
+);
+t_get($other_cluster);
 
 sub t_nodes {
   my $cluster = shift;


### PR DESCRIPTION
If you specify `lazy => 1` and `refresh_interval => 0` at the same time, the following errors occur.

```
ERR Target node not found. Maybe not all slots are served at t/03-commands.t line 92. 
```

This PR fixes the issue.