### PR TITLE
Send 'READONLY' command to all nodes using 'on_connect' attribute of 'Redis' package

### DIFF
--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -250,7 +250,6 @@ sub _prepare_nodes {
   my %nodes_pool;
   my @slots;
   my @masters_nodes;
-  my @slave_nodes;
 
   my $nodes_pool_old = $self->{_nodes_pool};
 
@@ -270,10 +269,6 @@ sub _prepare_nodes {
         }
         else {
           $nodes_pool{$hostport} = $self->_new_node($hostport);
-
-          unless ($is_master) {
-            push( @slave_nodes, $hostport );
-          }
         }
 
         if ($is_master) {
@@ -294,27 +289,6 @@ sub _prepare_nodes {
   $self->{_nodes}        = [ keys %nodes_pool ];
   $self->{_master_nodes} = \@masters_nodes;
   $self->{_slots}        = \@slots;
-
-  if ( $self->{allow_slaves} && @slave_nodes ) {
-    $self->_prepare_slaves( \@slave_nodes );
-  }
-
-  return;
-}
-
-sub _prepare_slaves {
-  my $self        = shift;
-  my $slave_nodes = shift;
-
-  foreach my $hostport ( @{$slave_nodes} ) {
-    local $@;
-
-    eval { $self->_run_command( 'readonly', [], [ $hostport ] ) };
-
-    if ($@) {
-      warn $@;
-    }
-  }
 
   return;
 }
@@ -373,6 +347,10 @@ sub _create_on_node_connect {
   weaken($self);
 
   return sub {
+    my $redis = shift;
+    if ( $self->{allow_slaves} ) {
+      $redis->readonly;
+    }
     if ( defined $self->{on_node_connect} ) {
       $self->{on_node_connect}->($hostport);
     }

--- a/t/03-commands.t
+++ b/t/03-commands.t
@@ -2,7 +2,7 @@ use 5.008000;
 use strict;
 use warnings;
 
-use Test::More tests => 12;
+use Test::More tests => 14;
 use Test::Fatal;
 BEGIN {
   require 't/test_helper.pl';
@@ -30,6 +30,20 @@ my $other_cluster = new_cluster(
   lazy => 1,
 );
 t_get($other_cluster);
+
+my $other_cluster_2 = new_cluster(
+  refresh_interval => 5,
+  cnx_timeout      => 5,
+  read_timeout     => 5,
+);
+t_failover($other_cluster_2, 1);
+my $other_cluster_3 = new_cluster(
+  allow_slaves     => 1,
+  refresh_interval => 5,
+  cnx_timeout      => 5,
+  read_timeout     => 5,
+);
+t_failover($other_cluster_3, 0);
 
 sub t_nodes {
   my $cluster = shift;
@@ -143,4 +157,45 @@ sub t_keys {
   is_deeply( \@t_reply, \@mock_keys, 'list; KEYS' );
 
   return;
+}
+
+sub t_failover {
+  my ( $cluster, $num_init ) = @_;
+
+  my $counter = 0;
+  my $orig_init = *{$Redis::ClusterRider::{_init}}{CODE};
+  local *Redis::ClusterRider::_init = sub {
+    $counter++;
+    goto &$orig_init;
+  };
+
+  update_command_replies(
+    cluster_slots => [
+      [ '0',
+        '5961',
+        [ '127.0.0.1', '7003', '14550b7425c44231090719acd5a5d42ad5424b4f' ],
+        [ '127.0.0.1', '7000', '4b2fa9c315cddbc1c1c729b60ade711fe141d61b' ],
+        [ '127.0.0.1', '7005', '050ece77147551db844467770883cf5cd2c8bc2b' ],
+      ],
+      [ '5962',
+        '10922',
+        [ '127.0.0.1', '7004', 'a859a49ad96f8312f91fc8c6b402484eda913c83' ],
+        [ '127.0.0.1', '7001', 'f7fc4a7c3f340ea44dc8f92a6fda041dc640de90' ],
+      ],
+      [ '10923',
+        '11421',
+        [ '127.0.0.1', '7003', '14550b7425c44231090719acd5a5d42ad5424b4f' ],
+        [ '127.0.0.1', '7000', '4b2fa9c315cddbc1c1c729b60ade711fe141d61b' ],
+        [ '127.0.0.1', '7005', '050ece77147551db844467770883cf5cd2c8bc2b' ],
+      ],
+      [ '11422',
+        '16383',
+        [ '127.0.0.1', '7006', '08c40bd2b18d9c2a20e6d8a27b8da283566a665d' ],
+        [ '127.0.0.1', '7002', '001dadcde7704079c3c6ea679323215c0930af57' ],
+      ],
+    ],
+  );
+
+  $cluster->get('foo');
+  is $counter, $num_init, 'GET; number of times _init() was called';
 }


### PR DESCRIPTION
# Overview
When an option 'allow_slaves' is enabled, 'CLUSTER SLOTS' command had been called not only for doing refresh by 'refresh_interval', but also for two cases (fork, failover) described below. With this PR, to reduce the call of 'CLUSTER SLOTS' command, the 'READONLY' command is sent to all nodes connected using the 'on_connect' attribute provided by the 'Redis' package. And, I wrote a test using the Mock that can reproduce at least the case of failover.

Referring to the implementation in other languages, it seemed that 'READONLY' will be sent to all the nodes. Therefore, I suppose this PR change is not a bad implementation.

- mediocregopher/radix 
  - a user manually send 'READONLY' to all connections by 'ClusterPoolFunc'. (#\198)
- mitsuhiko/redis-rs
  - 'READONLY' is sent to all nodes when the initial connection is created.
  - ref: https://github.com/mitsuhiko/redis-rs/blob/19dabdbf1538214d4fb0fd6ff505582e3d22baff/src/cluster.rs#L660 

## fork
When a fork occurs, the connection already established to the Cluster is destroyed. The created client can be used even after forking because 'Redis' package has auto reconnect feature. However 'Redis' package does not send 'READONLY' command to any nodes because that command has been sent by 'Redis::ClusterRider' side. Therefore, the client will use a connection not enabled readonly. With this PR, the 'READONLY' command will be sent by 'on_connect' attribute for recconection in 'Redis' package.

## failover
If failover occurs and master and slave are swapped, it may happen 'MOVED'. With This PR, 'READONLY' command will be sent to all nodes and we do not need to worry about failover. 
