### PR TITLE
Add Redis fallback unless cluster enabled #5

### DIFF
--- a/lib/Redis/ClusterRider.pm
+++ b/lib/Redis/ClusterRider.pm
@@ -87,7 +87,7 @@ sub new {
 
   if ( $params{fallback} ) {
     if ( $params{lazy} ) {
-      carp 'Fallback mode revokes lazy';
+      carp 'Fallback mode revokes lazy for ' . $params{startup_nodes}->[0];
     }
 
     my $node = Redis->new(%params, server => $params{startup_nodes}->[0]);


### PR DESCRIPTION
Implement fallback to Redis object if no cluster support enabled. Required additional connection inside new() call. Disabled by default. To enable, user can specify "fallback => 1" constructor parameter.
Default behaviour:
```
korg ~$ perl -Mlib=lib -MRedis::ClusterRider -le 'my $r = Redis::ClusterRider->new(startup_nodes => ["127.0.0.1:6379"]); print $r->hget("hash", "key")'
[cluster_info] ERR This instance has cluster support disabled,  at /usr/local/share/perl/5.28.1/Redis.pm line 275.
```
Improved behaviour:
```
korg ~$ perl -Mlib=lib -MRedis::ClusterRider -le 'my $r = Redis::ClusterRider->new(startup_nodes => ["127.0.0.1:6379"], fallback => 1); print $r->hget("hash", "key")'
Value
korg ~$
```